### PR TITLE
Add build requirements in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["scikit-build", "wheel"]


### PR DESCRIPTION
This allows pip to pick up and install scikit-build before running setup.py, thereby avoiding the "No module named 'skbuild'" error. Also include the wheel package, needed to build wheels.

This should allow pip to build elkai 0.1.2 from source from PyPI for systems without prebuilt wheels (once the source distribution is uploaded 🙂).